### PR TITLE
Add minimal echo bot implementation

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,50 @@
+import logging
+
+from telegram import Update
+from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
+
+from config import load_config
+
+
+logging.basicConfig(
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    level=logging.INFO,
+)
+logger = logging.getLogger(__name__)
+
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Обрабатывает команду /start."""
+
+    if update.message is None:
+        logger.debug("Получено событие без сообщения на /start")
+        return
+
+    await update.message.reply_text("Привет! Я echo-бот. Отправь мне что-нибудь, и я повторю.")
+
+
+async def echo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Отправляет пользователю ответ с тем же текстом."""
+
+    if update.message is None or update.message.text is None:
+        logger.debug("Получено событие без текста для echo")
+        return
+
+    await update.message.reply_text(update.message.text)
+
+
+def main() -> None:
+    """Точка входа для запуска бота."""
+
+    config = load_config()
+
+    application = Application.builder().token(config.token).build()
+    application.add_handler(CommandHandler("start", start))
+    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, echo))
+
+    logger.info("Бот запущен. Ожидание сообщений...")
+    application.run_polling()
+
+
+if __name__ == "__main__":
+    main()

--- a/config.py
+++ b/config.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+import os
+
+
+ENV_BOT_TOKEN = "BOT_TOKEN"
+
+
+@dataclass
+class BotConfig:
+    """Базовая конфигурация бота."""
+
+    token: str
+
+
+def load_config() -> BotConfig:
+    """Загружает конфигурацию бота из переменных окружения."""
+
+    token = os.getenv(ENV_BOT_TOKEN)
+    if not token:
+        raise ValueError(
+            "Не удалось найти токен бота. Убедитесь, что переменная окружения "
+            f"{ENV_BOT_TOKEN} задана."
+        )
+
+    return BotConfig(token=token)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-telegram-bot==20.8


### PR DESCRIPTION
## Summary
- add python-telegram-bot dependency specification
- introduce basic configuration loader for bot token
- implement minimal echo bot with start and text handlers

## Testing
- python -m compileall bot.py config.py

------
https://chatgpt.com/codex/tasks/task_e_68d17db33c80832ca3e97803faf80d9b